### PR TITLE
Fix SSL certificate validation for thumbnail and download proxies

### DIFF
--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -4,6 +4,14 @@ import { plexService } from '../services/plexService';
 import { logger } from '../utils/logger';
 import { AuthRequest, createAuthMiddleware } from '../middleware/auth';
 import axios from 'axios';
+import https from 'https';
+
+// HTTPS agent that bypasses SSL certificate validation for local Plex servers
+// This is necessary when connecting to Plex servers with self-signed certificates
+// or when using local IPs with plex.direct certificates
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: false
+});
 
 export const createMediaRouter = (db: DatabaseService) => {
   const router = Router();
@@ -434,6 +442,7 @@ export const createMediaRouter = (db: DatabaseService) => {
           method: 'GET',
           url: downloadUrl,
           responseType: 'stream',
+          httpsAgent: httpsAgent,
         });
       } catch (downloadError: any) {
         // If Plex returns 403, it means the user doesn't have download permission
@@ -548,6 +557,7 @@ export const createMediaRouter = (db: DatabaseService) => {
         method: 'GET',
         url: thumbUrl,
         responseType: 'stream',
+        httpsAgent: httpsAgent,
       });
 
       res.setHeader('Content-Type', response.headers['content-type'] || 'image/jpeg');


### PR DESCRIPTION
Extends the SSL certificate validation fix to the media routes that proxy thumbnails and downloads through the backend server.

Changes:
- Added HTTPS agent with rejectUnauthorized: false to media routes
- Updated thumbnail proxy endpoint to use HTTPS agent
- Updated download streaming endpoint to use HTTPS agent

This ensures that all axios requests to the Plex server bypass SSL validation, not just the metadata API calls.

Files modified:
- backend/src/routes/media.ts - Added HTTPS agent for thumbnail and download proxies